### PR TITLE
Jooble XML feed

### DIFF
--- a/app/helpers/vacancies_helper.rb
+++ b/app/helpers/vacancies_helper.rb
@@ -21,4 +21,66 @@ module VacanciesHelper
       a << [t("vacancies.employment_types.#{i}"), i]
     end
   end
+
+  def salary_to_human(vacancy)
+    if salary_range?(vacancy)
+      salary_range(vacancy)
+    elsif minimun_salary?(vacancy)
+      minimun_salary_with_prefix(vacancy)
+    elsif maximum_salary?(vacancy)
+      maximum_salary_with_prefix(vacancy)
+    else
+      t('vacancies.salary.not_defined')
+    end
+  end
+
+  def salary_with_currency(vacancy)
+    salary = salary_to_human(vacancy)
+
+    if vacancy.salary_currency
+      salary << ' ' << t("vacancies.currencies.#{vacancy.salary_currency}")
+    end
+
+    salary
+  end
+
+  def salary_with_units(vacancy)
+    salary = salary_with_currency(vacancy)
+
+    if vacancy.salary_unit
+      salary << ' ' << t("vacancies.salary_units.#{vacancy.salary_unit}")
+    end
+
+    salary
+  end
+
+  private
+
+  def salary_range?(vacancy)
+    minimun_salary?(vacancy) && maximum_salary?(vacancy)
+  end
+
+  def minimun_salary?(vacancy)
+    vacancy.salary_min && vacancy.salary_min.positive?
+  end
+
+  def maximum_salary?(vacancy)
+    vacancy.salary_max && vacancy.salary_max.positive?
+  end
+
+  def salary_range(vacancy)
+    range = [vacancy.salary_min, vacancy.salary_max].map do |number|
+      number_with_precision(number, precision: 0)
+    end
+    range.join('&ndash;')
+  end
+
+  # rubocop:disable Metrics/LineLength
+  def minimun_salary_with_prefix(vacancy)
+    t('vacancies.salary.prefix.min') << ' ' << number_with_precision(vacancy.salary_min, precision: 0)
+  end
+
+  def maximum_salary_with_prefix(vacancy)
+    t('vacancies.salary.prefix.max') << ' ' << number_with_precision(vacancy.salary_max, precision: 0)
+  end
 end

--- a/app/views/vacancies/index.jooblexml.builder
+++ b/app/views/vacancies/index.jooblexml.builder
@@ -2,16 +2,16 @@ xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
 xml.jobs do
   vacancies.each do |vacancy|
     xml.job id: vacancy.id do
-      xml.link vacancy_url(vacancy)
-      xml.name vacancy.title
-      xml.region company_location_tag(vacancy)
-      xml.description vacancy.description_html
-      xml.pubdate vacancy.created_at.iso8610
-      xml.updated vacancy.updated_at.iso8610
-      xml.salary salary_range(vacancy)
-      xml.company vacancy.company
-      xml.expire vacancy.expire_at.iso8610
-      xml.jobtype vacancy.employment_type
+      xml.link { xml.cdata! vacancy_url(vacancy) }
+      xml.name { xml.cdata! vacancy.title }
+      xml.region { xml.cdata! company_location_tag(vacancy) }
+      xml.description { xml.cdata! vacancy.description_html }
+      xml.pubdate { xml.cdata! vacancy.created_at.iso8601 }
+      xml.updated { xml.cdata! vacancy.updated_at.iso8601 }
+      xml.salary { xml.cdata! salary_with_units(vacancy) }
+      xml.company { xml.cdata! vacancy.company }
+      xml.expire { xml.cdata! vacancy.expire_at.iso8601 }
+      xml.jobtype { xml.cdata! t("vacancies.employment_types.#{vacancy.employment_type}") }
     end
   end
 end

--- a/app/views/vacancies/index.jooblexml.builder
+++ b/app/views/vacancies/index.jooblexml.builder
@@ -1,0 +1,17 @@
+xml.instruct! :xml, version: '1.0', encoding: 'UTF-8'
+xml.jobs do
+  vacancies.each do |vacancy|
+    xml.job id: vacancy.id do
+      xml.link vacancy_url(vacancy)
+      xml.name vacancy.title
+      xml.region company_location_tag(vacancy)
+      xml.description vacancy.description_html
+      xml.pubdate vacancy.created_at.iso8610
+      xml.updated vacancy.updated_at.iso8610
+      xml.salary salary_range(vacancy)
+      xml.company vacancy.company
+      xml.expire vacancy.expire_at.iso8610
+      xml.jobtype vacancy.employment_type
+    end
+  end
+end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -2,4 +2,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:
-# Mime::Type.register "text/richtext", :rtf
+Mime::Type.register 'application/vnd.jooble+xml', :jooblexml

--- a/config/locales/vacancies.ru.yml
+++ b/config/locales/vacancies.ru.yml
@@ -25,6 +25,11 @@ ru:
           project: "за проект"
       expire_at: "Заявления принимаются до %{expire_at}"
       expired: "Вакансия уже неактуальна и находится в архиве"
+    salary:
+      not_defined: "оплата оговаривается отдельно"
+      prefix:
+        min: "от"
+        max: "до"
     currencies:
       RUB: "рублей"
       EUR: "евро"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,4 +9,6 @@ Rails.application.routes.draw do
     resources :events, only: :create
     get 'page/:page', action: :index, on: :collection
   end
+
+  get 'feeds/jooble', to: 'vacancies#index', defaults: { format: :jooblexml }
 end

--- a/spec/fabricators/vacancy_fabricator.rb
+++ b/spec/fabricators/vacancy_fabricator.rb
@@ -4,6 +4,7 @@ Fabricator(:vacancy) do
   title { Faker::Lorem.sentence }
   description { Faker::Lorem.paragraph(5) }
   location { Faker::Address.city }
+  company { Faker::Company.name }
   email { Faker::Internet.email }
   expire_at { 1.week.from_now }
 end

--- a/spec/features/vacancies_jooble_feed_spec.rb
+++ b/spec/features/vacancies_jooble_feed_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe 'Vacancies Jooble feed' do
+  let!(:approved_vacancy) { persist_vacancy(build(:approved_vacancy)) }
+  let!(:disapproved_vacancy) { persist_vacancy(build(:disapproved_vacancy)) }
+  let!(:archived_vacancy) { persist_vacancy(build(:archived_vacancy)) }
+
+  subject { page }
+
+  before { visit feeds_jooble_path }
+
+  it 'displays vacancies in XML format' do
+    expect(subject.body).to start_with('<?xml')
+  end
+
+  it 'displays approved vacancy' do
+    expect(subject.body).to include(approved_vacancy.title)
+  end
+
+  it 'does not display disapproved vacancy' do
+    expect(subject.body).not_to include(disapproved_vacancy.title)
+  end
+
+  it 'does not display archived/expired vacancy' do
+    expect(subject.body).not_to include(archived_vacancy.title)
+  end
+end

--- a/spec/helpers/vacancies_helper_spec.rb
+++ b/spec/helpers/vacancies_helper_spec.rb
@@ -53,4 +53,98 @@ RSpec.describe VacanciesHelper do
       end
     end
   end
+
+  describe '#salary_to_human' do
+    before do
+      vacancy.salary_min = 100
+      vacancy.salary_max = 200
+      vacancy.salary_currency = Vacancy::CURRENCY_EUR
+    end
+
+    it 'concatinates salary numbers using en dash' do
+      expect(subject.salary_to_human(vacancy)).to eql('100&ndash;200')
+    end
+
+    context 'when minimum number is omitted' do
+      before do
+        vacancy.salary_min = nil
+      end
+
+      it 'uses only maximum number with prefix' do
+        expect(subject.salary_to_human(vacancy)).to eql('до 200')
+      end
+    end
+
+    context 'when maximum number is omitted' do
+      before do
+        vacancy.salary_max = nil
+      end
+
+      it 'uses only minimum number with prefix' do
+        expect(subject.salary_to_human(vacancy)).to eql('от 100')
+      end
+    end
+
+    context 'when salary range is not stated' do
+      before do
+        vacancy.salary_min = nil
+        vacancy.salary_max = nil
+      end
+
+      it 'returns default "not defined" message' do
+        expect(subject.salary_to_human(vacancy)).to eql(
+          t('vacancies.salary.not_defined')
+        )
+      end
+    end
+  end
+
+  describe '#salary_with_currency' do
+    before do
+      vacancy.salary_min = 100
+      vacancy.salary_max = 200
+      vacancy.salary_currency = Vacancy::CURRENCY_EUR
+    end
+
+    it 'concatinates salary human numbers with currency' do
+      salary = subject.salary_to_human(vacancy)
+      expect(subject.salary_with_currency(vacancy)).to eql("#{salary} евро")
+    end
+
+    context 'when currency is not stated' do
+      before do
+        vacancy.salary_currency = nil
+      end
+
+      it 'returns just salary numbers' do
+        salary = subject.salary_to_human(vacancy)
+        expect(subject.salary_with_currency(vacancy)).to eql(salary)
+      end
+    end
+  end
+
+  describe '#salary_with_units' do
+    before do
+      vacancy.salary_min = 100
+      vacancy.salary_max = 200
+      vacancy.salary_currency = Vacancy::CURRENCY_EUR
+      vacancy.salary_unit = Vacancy::SALARY_UNIT_HOUR
+    end
+
+    it 'concatinates salary line with units' do
+      salary = subject.salary_with_currency(vacancy)
+      expect(subject.salary_with_units(vacancy)).to eql("#{salary} в час")
+    end
+
+    context 'when units are not stated' do
+      before do
+        vacancy.salary_unit = nil
+      end
+
+      it 'returns just salary line' do
+        salary = subject.salary_with_currency(vacancy)
+        expect(subject.salary_with_units(vacancy)).to eql(salary)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Implementation of https://github.com/rubyjobsru/app/issues/23.

A new `GET /feeds/jooble` path has been added and it responds with an XML representation of available vacancies in Jooble format.